### PR TITLE
Event Listeners for guildAdd and guildDelete - Resolves #18

### DIFF
--- a/lib/onEvent.js
+++ b/lib/onEvent.js
@@ -1,6 +1,6 @@
 require('./onEvent/ready');
 require('./onEvent/message');
-require('./onEvent/guildAdd');
+require('./onEvent/guildCreate');
 require('./onEvent/guildDelete');
 require('./onEvent/guildMemberAdd');
 require('./onEvent/disconnected');

--- a/lib/onEvent.js
+++ b/lib/onEvent.js
@@ -1,4 +1,6 @@
 require('./onEvent/ready');
 require('./onEvent/message');
+require('./onEvent/guildAdd');
+require('./onEvent/guildDelete');
 require('./onEvent/guildMemberAdd');
 require('./onEvent/disconnected');

--- a/lib/onEvent/guildCreate.js
+++ b/lib/onEvent/guildCreate.js
@@ -1,3 +1,3 @@
-client.on("guildCreate", guild => {
+client.on('guildCreate', guild => {
     GReYBot.user.setGame(`${GReYBotConfig.commandPrefix}help | ${GReYBot.guilds.array().length} Servers`);
 });

--- a/lib/onEvent/guildCreate.js
+++ b/lib/onEvent/guildCreate.js
@@ -1,0 +1,3 @@
+client.on("guildCreate", guild => {
+    GReYBot.user.setGame(`${GReYBotConfig.commandPrefix}help | ${GReYBot.guilds.array().length} Servers`);
+});

--- a/lib/onEvent/guildDelete.js
+++ b/lib/onEvent/guildDelete.js
@@ -1,0 +1,3 @@
+client.on("guildDelete", guild => {
+    GReYBot.user.setGame(`${GReYBotConfig.commandPrefix}help | ${GReYBot.guilds.array().length} Servers`);
+});

--- a/lib/onEvent/guildDelete.js
+++ b/lib/onEvent/guildDelete.js
@@ -1,3 +1,3 @@
-client.on("guildDelete", guild => {
+client.on('guildDelete', guild => {
     GReYBot.user.setGame(`${GReYBotConfig.commandPrefix}help | ${GReYBot.guilds.array().length} Servers`);
 });


### PR DESCRIPTION
Event listeners `guildAdd` and `guildDelete` fire when the bot joins/parts a guild's server